### PR TITLE
feat: Display git errors to the user

### DIFF
--- a/describerr/describerr.py
+++ b/describerr/describerr.py
@@ -2,6 +2,7 @@ import io
 import re
 import shlex
 import subprocess
+import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import date
@@ -181,7 +182,9 @@ class Describerr:
         git_command = f'git log {log_range} --pretty="%s <%an>"'
         result = subprocess.run(shlex.split(git_command), capture_output=True)
         logger.info(f"Getting commits using command: {git_command}")
-        result.check_returncode()
+        if result.returncode != 0:
+            logger.error(f"Most probably tag(s) does not exist. Git error:\n{result.stderr.decode()}")
+            sys.exit(result.returncode)
         stdout = result.stdout.decode().strip().split("\n")
         logger.debug(stdout)
         for commit_raw_str in stdout:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import logging
+
 import pytest
+from loguru import logger
 
 
 @pytest.fixture
@@ -13,3 +16,16 @@ def changelog():
     with open("resources/CHANGELOG.md", "r") as f:
         changelog = f.read()
         yield changelog
+
+
+@pytest.fixture
+def caplog(caplog):
+    """Override pytest caplog fixture in order to work properly with loguru module"""
+
+    class PropagateHandler(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = logger.add(PropagateHandler(), format="{message}")
+    yield caplog
+    logger.remove(handler_id)


### PR DESCRIPTION
Previously only `CalledProcessorError` was presented, original errors were not shown.

Fixes: #7